### PR TITLE
Add a shortcut example

### DIFF
--- a/src/static/js/app.custom.js
+++ b/src/static/js/app.custom.js
@@ -1,4 +1,19 @@
 /*
+ * ShortCut click event
+ */
+$('#shortcut').on('click', 'a', function(){
+    var $a = $(this);
+    var name = $a.find('.shortcut-name').text();
+    $('#shortcut > li > a').removeClass('selected');
+    $a.addClass('selected');
+});
+
+function getShortCutName() {
+    var $a = $('#shortcut a.selected');
+    if($a.length === 1) return $a.find('.shortcut-name').text();
+}
+
+/*
  * Custom load multiple script in order by loadScript()
  */
 function scriptLoader (scriptArray, callback) {

--- a/src/static/js/highcharts/chart1Helper.js
+++ b/src/static/js/highcharts/chart1Helper.js
@@ -302,7 +302,7 @@ var chart1Helper = {
             },
 
             subtitle: {
-                text: getBreadCrumb(' / '),
+                text: getBreadCrumb(' / ') !== "" ? getBreadCrumb(' / ') : getShortCutName(),
                 style: {
                     fontSize: chart1Helper.manager.fontSize.label,
                     display: thisDevice == 'desktop' ? 'block' : 'none',

--- a/src/static/js/highcharts/chart2Helper.js
+++ b/src/static/js/highcharts/chart2Helper.js
@@ -12,7 +12,6 @@ var chart2Helper = {
             title: 11,
         },
         title: gettext('Daily Price/Volume Trend For All Time'),
-        subtitle: getBreadCrumb ? getBreadCrumb(' / ') : null,
         colorLevel: {
             marker: {
                 danger: '#b94a48',
@@ -328,7 +327,7 @@ var chart2Helper = {
             },
 
             subtitle: {
-                text: getBreadCrumb(' / '),
+                text: getBreadCrumb(' / ') !== "" ? getBreadCrumb(' / ') : getShortCutName(),
                 style: {
                     fontSize: chart2Helper.manager.fontSize.label,
                     display: thisDevice == 'desktop' ? 'block' : 'none',

--- a/src/static/js/highcharts/chart3Helper.js
+++ b/src/static/js/highcharts/chart3Helper.js
@@ -93,7 +93,7 @@ var chart3Helper = {
             },
 
             subtitle: {
-                text: getBreadCrumb(' / '),
+                text: getBreadCrumb(' / ') !== "" ? getBreadCrumb(' / ') : getShortCutName(),
                 style: {
                     fontSize: chart3Helper.manager.fontSize.label,
                     display: thisDevice == 'desktop' ? 'block' : 'none',

--- a/src/static/js/highcharts/chart4Helper.js
+++ b/src/static/js/highcharts/chart4Helper.js
@@ -111,7 +111,7 @@ var chart4Helper = {
             },
 
             subtitle: {
-                text: getBreadCrumb(' / '),
+                text: getBreadCrumb(' / ') !== "" ? getBreadCrumb(' / ') : getShortCutName(),
                 style: {
                     fontSize: chart4Helper.manager.fontSize.label,
                     display: thisDevice == 'desktop' ? 'block' : 'none',

--- a/src/static/js/highcharts/chart5Helper.js
+++ b/src/static/js/highcharts/chart5Helper.js
@@ -119,7 +119,7 @@ var chart5Helper = {
             },
 
             subtitle: {
-                text: getBreadCrumb(' / '),
+                text: getBreadCrumb(' / ') !== "" ? getBreadCrumb(' / ') : getShortCutName(),
                 style: {
                     fontSize: chart5Helper.manager.fontSize.label,
                     display: thisDevice == 'desktop' ? 'block' : 'none',

--- a/src/templates/shortcut.html
+++ b/src/templates/shortcut.html
@@ -5,7 +5,8 @@
 <div id="shortcut">
     <ul>
         <li>
-            <a href="#{% url 'about' %}" class="jarvismetro-tile big-cubes bg-color-blue"> <span class="iconbox"> <i class="fa fa-info fa-4x"></i> <span>{% trans 'About' %}</span></span></a>
+            <!-- advise .shortcut-name to span -->
+            <a href="#{% url 'chart_tab' wi=1 ct='config' oi=8 %}" class="jarvismetro-tile big-cubes bg-color-blue"> <span class="iconbox"> <i class="fa fa-crosshairs fa-4x"></i> <span class="shortcut-name">總體毛豬</span></span></a>
         </li>
     </ul>
 </div>

--- a/src/watchlists/builder.py
+++ b/src/watchlists/builder.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import User
 from .models import (
     Watchlist, WatchlistItem
 )
+from django.utils.translation import ugettext_lazy as _
 from configs.models import AbstractProduct
 
 
@@ -9,13 +10,16 @@ def build_all():
     """
     create or update a watchlist with watch_all = True and related to all tracked product, sources
     """
-    name = '全部'
-    user = User.objects.filter(is_superuser=True).first()
+    name = _('All')
 
-    watchlist, created = Watchlist.objects.update_or_create(
-        watch_all=True, name=name, user=user
-    )
+    # user = User.objects.filter(is_superuser=True).first()
+    # watchlist, created = Watchlist.objects.update_or_create(
+    #     watch_all=True, name=name, user=user
+    # )
 
+    watchlist, created = Watchlist.objects.update_or_create(id=1)
+
+    # if first build, remove all children and rebuild
     if not created:
         WatchlistItem.objects.filter(parent=watchlist).all().delete()
 


### PR DESCRIPTION
Further features: user can store shortcut under specific
watchlist, product or any ajax pages

1. Add an example(overall hog)
2. Add getShortCutName to access current selected shortcut name
3. Charts call getShortCutName() to get its subtitle
4. Restrict watch_all watchlist's id = 1 in watchlists.builder.build_all

Please do this after fetch to server:
1. build_all()
2. collectstatics